### PR TITLE
Disable sympy cache

### DIFF
--- a/cameo/Dockerfile
+++ b/cameo/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.6-slim
 
 ENV PYTHONUNBUFFERED=1
+# The sympy cache causes significant memory leaks as it is currently used by
+# optlang. Disable it by default.
+ENV SYMPY_USE_CACHE=no
 
 ARG CWD=/opt
 ARG REPO_URL


### PR DESCRIPTION
I suggest we disable this by default in the base image for all decaf modeling services.