### PR TITLE
Base image on wsgi-base

### DIFF
--- a/cameo/.dockerignore
+++ b/cameo/.dockerignore
@@ -1,3 +1,3 @@
 *
-!requirements.in
+!modeling-requirements.in
 !download_solver.py

--- a/cameo/Dockerfile
+++ b/cameo/Dockerfile
@@ -14,18 +14,18 @@ ARG CPLEX="cplex_128.tar.gz"
 WORKDIR /opt
 
 COPY modeling-requirements.in ./
-
-RUN set -eux \
-    && pip-compile --generate-hashes \
-        --output-file modeling-requirements.txt modeling-requirements.in \
-    && pip-sync modeling-requirements.txt
-
-# Install CPLEX.
-
 COPY download_solver.py ./
 
 RUN set -eux \
+    # Install CPLEX first from the external source.
     && python3 download_solver.py "${CPLEX}" \
     && tar -xzf "${CPLEX}" \
     && pip --no-cache-dir install cplex_128/python/3.6/x86-64_linux \
-    && rm -rf cplex_128*
+    && rm -rf cplex_128* \
+    # Compile all the modeling requirements. Note that `pip-compile` will use
+    # the local installation of cplex.
+    && pip-compile --generate-hashes \
+        --output-file modeling-requirements.txt modeling-requirements.in \
+    # Pre-install the compiled requirements to save some build time for child
+    # images.
+    && pip-sync modeling-requirements.txt

--- a/cameo/Dockerfile
+++ b/cameo/Dockerfile
@@ -1,34 +1,26 @@
-FROM python:3.6-slim
+FROM dddecaf/wsgi-base:debian
 
-ENV PYTHONUNBUFFERED=1
 # The sympy cache causes significant memory leaks as it is currently used by
 # optlang. Disable it by default.
 ENV SYMPY_USE_CACHE=no
 
-ARG CWD=/opt
+# CPLEX is provided externally; see the README
 ARG REPO_URL
 ARG GITHUB_TOKEN
 ARG CPLEX="cplex_128.tar.gz"
 
-RUN set -eux \
-    && apt-get update \
-    && apt-get install --yes --only-upgrade openssl ca-certificates \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Work in the /opt directory to persist the pip-compiled requirement list for
+# child images to use.
+WORKDIR /opt
 
-WORKDIR "${CWD}"
-
-COPY requirements.in ./
+COPY modeling-requirements.in ./
 
 RUN set -eux \
-    && pip install --upgrade pip setuptools wheel pip-tools \
     && pip-compile --generate-hashes \
-        --output-file requirements.txt requirements.in \
-    && pip-sync requirements.txt \
-    && rm -rf /root/.cache \
-    && rm -rf /tmp/* /var/tmp/*
+        --output-file modeling-requirements.txt modeling-requirements.in \
+    && pip-sync modeling-requirements.txt
 
-# Install CPLEX afterwards when pip was already upgraded.
+# Install CPLEX.
 
 COPY download_solver.py ./
 

--- a/cameo/modeling-requirements.in
+++ b/cameo/modeling-requirements.in
@@ -1,0 +1,12 @@
+# Include the base requirements, but NOT the pre-compiled constraints. If there
+# is a reason to do re-use those, the following incompatibility (and possibly
+# more) in the resolved dependencies would have to be adressed:
+#   pytest==5.2.2 (from -r /opt/base-requirements.txt (line 297))
+#   pytest<5,>=4.0.1 (from escher==1.7.3->cameo==0.11.15->-r modeling-requirements.in (line 7))
+#   pytest>=3.6 (from pytest-cov==2.8.1->-r /opt/base-requirements.txt (line 294))
+-r /opt/base-requirements.in
+
+# Modeling libraries
+python-libsbml
+cobra
+cameo

--- a/cameo/modeling-requirements.in
+++ b/cameo/modeling-requirements.in
@@ -10,3 +10,7 @@
 python-libsbml
 cobra
 cameo
+
+# CPLEX - is installed externally, but include it to ensure pip-sync does not
+# uninstall it later.
+cplex==12.8.0.0

--- a/cameo/modeling-requirements.in
+++ b/cameo/modeling-requirements.in
@@ -7,7 +7,6 @@
 -r /opt/base-requirements.in
 
 # Modeling libraries
-python-libsbml
 cobra
 cameo
 

--- a/cameo/requirements.in
+++ b/cameo/requirements.in
@@ -1,3 +1,0 @@
-python-libsbml
-cobra
-cameo


### PR DESCRIPTION
- `wsgi-base` now includes one `alpine` and one `debian` version, this now builds on the latter (https://github.com/DD-DeCaF/wsgi-base/pull/2)
- We cannot use the compiled constraints from the base image, because they are incompatible with dependency constraints in some of our services, so here we're simply recompiling with the input requirements from the base image.
- Install cplex first to ensure that it is included in the pip-tools workflow