### PR TITLE
feat: add compiler image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,19 @@ env:
   global:
   - IMAGE_REPO=gcr.io/dd-decaf-cfbf6/modeling-base
   - IMAGE=${IMAGE_REPO}:${TRAVIS_BRANCH}
+before_install:
+- "./scripts/install_gcloud.sh"
 install:
 - make build
+- docker build -t ${IMAGE_REPO}:compiler ./compiler
 script:
 - make safety
 after_success:
-- "./scripts/install_gcloud.sh"
 - docker tag ${IMAGE} ${IMAGE_REPO}:${TRAVIS_COMMIT::12}
 - docker tag ${IMAGE} ${IMAGE_REPO}:${TRAVIS_BRANCH}
 - docker push ${IMAGE_REPO}:${TRAVIS_COMMIT::12}
 - docker push ${IMAGE_REPO}:${TRAVIS_BRANCH}
+- docker push ${IMAGE_REPO}:compiler
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - "./scripts/install_gcloud.sh"
 install:
 - make build
-- docker build -t ${IMAGE_REPO}:compiler ./compiler
+- docker build -t ${IMAGE_REPO}:compiler -t ${IMAGE_REPO}:compiler-${IMAGE_HASH_TAG} ./compiler
 script:
 - make safety
 after_success:
@@ -25,6 +25,7 @@ after_success:
 - docker push ${IMAGE_REPO}:${TRAVIS_COMMIT::12}
 - docker push ${IMAGE_REPO}:${TRAVIS_BRANCH}
 - docker push ${IMAGE_REPO}:compiler
+- docker push ${IMAGE_REPO}:compiler-${IMAGE_HASH_TAG}
 notifications:
   email: false
   slack:

--- a/cameo/Dockerfile
+++ b/cameo/Dockerfile
@@ -29,6 +29,5 @@ RUN set -eux \
     # Pre-install the compiled requirements to save some build time for child
     # images.
     && pip-sync modeling-requirements.txt \
-    # Delete the pip cache to minimize image size. Note that the pip-tools
-    # cache is kept to speed up `pip-compile` in child images.
-    && rm -rf /root/.cache/pip
+    # Delete the pip cache to minimize image size.
+    && rm -rf /root/.cache

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcr.io/dd-decaf-cfbf6/modeling-base:master
+
+RUN set -eux \
+    # Install build tools. These can be required for the `pip-compile` step in
+    # child images that require to build packages from source.
+    && apt-get update \
+    && apt-get install --yes build-essential \
+    # Re-run pip-compile in order to pre-populate the pip cache.
+    && pip-compile --generate-hashes --output-file /dev/null \
+      /opt/modeling-requirements.txt \
+    # Clean up to reduce layer size.
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The compiler image contains build tools and the pip cache, and can be
used to perform `pip-compile` in child services.